### PR TITLE
feat: Transfer data from wordpress #22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -535,3 +535,6 @@ FodyWeavers.xsd
 # End of https://www.toptal.com/developers/gitignore/api/visualstudio
 
 .env
+.tmp/
+.codex/
+.claude/

--- a/src/api/category/content-types/category/schema.json
+++ b/src/api/category/content-types/category/schema.json
@@ -18,7 +18,8 @@
     "slug": {
       "type": "uid",
       "targetField": "name",
-      "required": true
+      "required": true,
+      "regex": "^[^\\s/]+$"
     },
     "description": {
       "type": "text"

--- a/src/api/post/content-types/post/schema.json
+++ b/src/api/post/content-types/post/schema.json
@@ -17,7 +17,8 @@
     },
     "slug": {
       "type": "uid",
-      "targetField": "title"
+      "targetField": "title",
+      "regex": "^[^\\s/]+$"
     },
     "content": {
       "type": "blocks",
@@ -72,6 +73,9 @@
       "repeatable": true
     },
     "markdownContent": {
+      "type": "richtext"
+    },
+    "htmlContent": {
       "type": "richtext"
     }
   }

--- a/src/api/tag/content-types/tag/schema.json
+++ b/src/api/tag/content-types/tag/schema.json
@@ -17,7 +17,8 @@
     },
     "slug": {
       "type": "uid",
-      "targetField": "name"
+      "targetField": "name",
+      "regex": "^[^\\s/]+$"
     },
     "posts": {
       "type": "relation",

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -490,6 +490,7 @@ export interface ApiPostPost extends Struct.CollectionTypeSchema {
     featuredImage: Schema.Attribute.Media<
       'images' | 'files' | 'videos' | 'audios'
     >;
+    htmlContent: Schema.Attribute.RichText;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::post.post'> &
       Schema.Attribute.Private;


### PR DESCRIPTION
## Summary

WordPress WXR XML 데이터를 Strapi로 마이그레이션하기 위한 스키마 변경 사항을 반영합니다.

- `post`, `category`, `tag` 콘텐츠 타입의 `slug` 필드에 regex 유효성 검사(`^[^\s/]+$`) 추가
- `post` 콘텐츠 타입에 `htmlContent` (richtext) 필드 추가 — WordPress 원문 HTML 보존용
- `types/generated/contentTypes.d.ts` 자동 생성 타입 파일 업데이트 (`htmlContent` 필드 반영)
- `.gitignore`에 `.tmp/`, `.codex/`, `.claude/` 경로 추가 (임포트 스크립트 및 작업 디렉터리 제외)

## Changes

- `src/api/post/content-types/post/schema.json`: `slug` regex 추가, `htmlContent` richtext 필드 신규 추가
- `src/api/category/content-types/category/schema.json`: `slug` regex 추가
- `src/api/tag/content-types/tag/schema.json`: `slug` regex 추가
- `types/generated/contentTypes.d.ts`: `ApiPostPost`에 `htmlContent: Schema.Attribute.RichText` 추가
- `.gitignore`: `.tmp/`, `.codex/`, `.claude/` 제외 규칙 추가

## Related Issues

Closes #22

## Testing

- WordPress XML(1,464개 포스트)에서 Strapi로 전체 임포트 완료
- `htmlContent` 백필 스크립트 실행 결과: 1,463/1,463 성공, WARN/ERROR 0건
- 임포트 스크립트는 `.tmp/` 디렉터리에 위치하며 gitignore 처리됨 (PR에 포함되지 않음)

## Notes

임포트 스크립트 (`fast-xml-parser`, `cheerio`, `turndown` 등을 사용하는 TypeScript 프로젝트)는 `.tmp/src/` 에 위치하며 이 PR에 포함되지 않습니다.
전체 임포트 결과: 1,463개 포스트, 66개 미디어(WP ID 기준), 388개 미디어(URL 기준) 성공적으로 Strapi에 저장됨.